### PR TITLE
Add login, signup, logout api; both the authController and usersTable…

### DIFF
--- a/bookmarket-backend/src/main/java/edu/oakland/sophomoreproject/controllers/AuthController.java
+++ b/bookmarket-backend/src/main/java/edu/oakland/sophomoreproject/controllers/AuthController.java
@@ -1,8 +1,10 @@
 package edu.oakland.sophomoreproject.controllers;
 
+import edu.oakland.sophomoreproject.authorization.SessionAuthorizer;
 import edu.oakland.sophomoreproject.components.ControllerUtils;
 import edu.oakland.sophomoreproject.controllers.requests.LoginRequest;
 import edu.oakland.sophomoreproject.controllers.requests.SignUpRequest;
+import edu.oakland.sophomoreproject.model.auth.UserWithoutId;
 import edu.oakland.sophomoreproject.model.sessions.Session;
 import edu.oakland.sophomoreproject.dependencies.sqlite.sessions.SessionsTableAccessor;
 import edu.oakland.sophomoreproject.dependencies.sqlite.users.UsersTableAccessor;
@@ -14,19 +16,23 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.sql.SQLException;
+import java.time.Instant;
 
 @RestController
 public class AuthController {
 	private final ControllerUtils controllerUtils;
+	private final SessionAuthorizer sessionAuthorizer;
 	private final UsersTableAccessor usersTableAccessor;
 	private final SessionsTableAccessor sessionsTableAccessor;
 
 	public AuthController(
 			ControllerUtils controllerUtils,
+			SessionAuthorizer sessionAuthorizer,
 			UsersTableAccessor usersTableAccessor,
 			SessionsTableAccessor sessionsTableAccessor
 	) {
 		this.controllerUtils = controllerUtils;
+		this.sessionAuthorizer = sessionAuthorizer;
 		this.usersTableAccessor = usersTableAccessor;
 		this.sessionsTableAccessor = sessionsTableAccessor;
 	}
@@ -35,13 +41,11 @@ public class AuthController {
 	public ResponseEntity<Void> login(
 			HttpServletRequest request,
 			@RequestBody LoginRequest payload
-) throws SQLException {
+	) throws SQLException {
 		int userId = 0;
-		// ... do logic here and get the correct user id
-
 		Session session = Session.newRandomSession(userId);
 
-		HttpHeaders httpHeaders = controllerUtils.getHeadersWithSessionCookie(session);
+        HttpHeaders httpHeaders = controllerUtils.getHeadersWithSessionCookie(session);
 		return ResponseEntity.ok().headers(httpHeaders).build();
 	}
 
@@ -51,7 +55,18 @@ public class AuthController {
 			@RequestBody SignUpRequest payload
 	) throws SQLException {
 		int userId = 0;
-		// ... do logic here and get the correct user id
+
+		Instant now = Instant.now();
+
+		UserWithoutId userWithoutId = new UserWithoutId(
+				payload.getFirstName(),
+				payload.getLastName(),
+				payload.getEmail(),
+				payload.getPassword(),
+				payload.getCreatedAt()
+		);
+
+		userId = usersTableAccessor.createUser(userWithoutId);
 
 		Session session = Session.newRandomSession(userId);
 
@@ -60,10 +75,16 @@ public class AuthController {
 	}
 
 	@PostMapping("/api/auth/logout")
-	public ResponseEntity<Void> logout(HttpServletRequest request) {
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Set-Cookie", "session='';Expires=0");
+	public ResponseEntity<Void> logout(HttpServletRequest request) throws SQLException {
+			Session session = sessionAuthorizer.authorize(request);
+			if (session != null) {
+				sessionsTableAccessor.deleteSessionById(session.getSessionId());
+			}
 
-		return ResponseEntity.ok().headers(headers).build();
+			HttpHeaders headers = new HttpHeaders();
+			headers.add("Set-Cookie", "session='';Expires=0");
+
+			return ResponseEntity.ok().headers(headers).build();
+
 	}
 }

--- a/bookmarket-backend/src/main/java/edu/oakland/sophomoreproject/controllers/AuthController.java
+++ b/bookmarket-backend/src/main/java/edu/oakland/sophomoreproject/controllers/AuthController.java
@@ -63,7 +63,7 @@ public class AuthController {
 				payload.getLastName(),
 				payload.getEmail(),
 				payload.getPassword(),
-				payload.getCreatedAt()
+				now
 		);
 
 		userId = usersTableAccessor.createUser(userWithoutId);

--- a/bookmarket-backend/src/main/java/edu/oakland/sophomoreproject/controllers/requests/SignUpRequest.java
+++ b/bookmarket-backend/src/main/java/edu/oakland/sophomoreproject/controllers/requests/SignUpRequest.java
@@ -16,7 +16,6 @@ public class SignUpRequest {
 	private String firstName;
 	private String lastName;
 	private String password;
-	private Instant createdAt;
 
 	public String getEmail() {
 		return email;
@@ -49,9 +48,5 @@ public class SignUpRequest {
 	public void setPassword(String password) {
 		this.password = password;
 	}
-
-	public Instant getCreatedAt() { return createdAt; }
-
-	public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
 
 }

--- a/bookmarket-backend/src/main/java/edu/oakland/sophomoreproject/controllers/requests/SignUpRequest.java
+++ b/bookmarket-backend/src/main/java/edu/oakland/sophomoreproject/controllers/requests/SignUpRequest.java
@@ -5,6 +5,8 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
+import java.time.Instant;
+
 @ToString
 @EqualsAndHashCode
 @NoArgsConstructor
@@ -14,6 +16,7 @@ public class SignUpRequest {
 	private String firstName;
 	private String lastName;
 	private String password;
+	private Instant createdAt;
 
 	public String getEmail() {
 		return email;
@@ -46,4 +49,9 @@ public class SignUpRequest {
 	public void setPassword(String password) {
 		this.password = password;
 	}
+
+	public Instant getCreatedAt() { return createdAt; }
+
+	public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+
 }

--- a/bookmarket-backend/src/main/java/edu/oakland/sophomoreproject/dependencies/sqlite/users/UsersTableAccessor.java
+++ b/bookmarket-backend/src/main/java/edu/oakland/sophomoreproject/dependencies/sqlite/users/UsersTableAccessor.java
@@ -22,19 +22,23 @@ public class UsersTableAccessor extends TableAccessor {
 	}
 
 	public User getUserById(int userId) throws SQLException {
-		String sql = "SELECT * FROM users WHERE userId = ? LIMIT 1";
-
 		Connection connection = getDatabaseConnection();
+		String sql = "SELECT id, first_name, last_name, email, password, created_at FROM users WHERE userId = ? LIMIT 1";
+
 		PreparedStatement sqlQuery = connection.prepareStatement(sql);
 		sqlQuery.setInt(1, userId);
 
 		ResultSet results = sqlQuery.executeQuery();
 
 		if (results.next()) {
+			String firstName = results.getString("first_name");
+			String lastName = results.getString("last_name");
 			String email = results.getString("email");
 			String password = results.getString("password");
-		}
+			Instant createdAt = results.getTimestamp("created_at").toInstant();
 
+			return new User(userId, firstName, lastName, email, password, createdAt);
+		}
 		return null;
 	}
 
@@ -46,8 +50,10 @@ public class UsersTableAccessor extends TableAccessor {
 
 		Connection connection = getDatabaseConnection();
 		PreparedStatement sqlStatement = connection.prepareStatement(sql);
-		sqlStatement.setString(1, userWithoutId.getEmail());
-		sqlStatement.setString(2, userWithoutId.getPassword());
+		sqlStatement.setString(1, userWithoutId.getFirstName());
+		sqlStatement.setString(2, userWithoutId.getLastName());
+		sqlStatement.setString(3, userWithoutId.getEmail());
+		sqlStatement.setString(4, userWithoutId.getPassword());
 
 		sqlStatement.executeUpdate();
 

--- a/bookmarket-backend/src/main/java/edu/oakland/sophomoreproject/dependencies/sqlite/users/UsersTableAccessor.java
+++ b/bookmarket-backend/src/main/java/edu/oakland/sophomoreproject/dependencies/sqlite/users/UsersTableAccessor.java
@@ -6,6 +6,13 @@ import edu.oakland.sophomoreproject.model.auth.UserWithoutId;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.sqlite.SQLiteConfig;
+import org.sqlite.SQLiteException;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
 
 @Component
 public class UsersTableAccessor extends TableAccessor {
@@ -14,15 +21,42 @@ public class UsersTableAccessor extends TableAccessor {
 		super(sqliteConfig);
 	}
 
-	public User getUserById(int userId) {
-		// TODO
+	public User getUserById(int userId) throws SQLException {
+		String sql = "SELECT * FROM users WHERE userId = ? LIMIT 1";
+
+		Connection connection = getDatabaseConnection();
+		PreparedStatement sqlQuery = connection.prepareStatement(sql);
+		sqlQuery.setInt(1, userId);
+
+		ResultSet results = sqlQuery.executeQuery();
+
+		if (results.next()) {
+			String email = results.getString("email");
+			String password = results.getString("password");
+		}
+
 		return null;
 	}
 
 	/// this object is UserWithoutId because we will get the ID from SQL after creating it
 	/// this can be done by doing `INSERT INTO users ... RETURNING user_id`
 	/// and parsing the `user_id` column it returns with `results.getString("user_id")`
-	public void createUser(UserWithoutId userWithoutId) {
-		// TODO
+	public int createUser(UserWithoutId userWithoutId) throws SQLException {
+		String sql = "INSERT INTO users (email, password) VALUES (?, ?) RETURNING user_id";
+
+		Connection connection = getDatabaseConnection();
+		PreparedStatement sqlStatement = connection.prepareStatement(sql);
+		sqlStatement.setString(1, userWithoutId.getEmail());
+		sqlStatement.setString(2, userWithoutId.getPassword());
+
+		sqlStatement.executeUpdate();
+
+		ResultSet generatedKeys = sqlStatement.getGeneratedKeys();
+
+		if (generatedKeys.next()) {
+			return generatedKeys.getInt(1);
+		} else {
+			throw new SQLException();
+		}
 	}
 }


### PR DESCRIPTION
…Accessor

### Notes
- The AuthController includes login, signup, and logout
- The UsersTableAccessor includes getUserById and createUser
- I also added createdAt to SignUpRequest so payload.getCreatedAt() in AuthController works
- I also change the return type of createUser from void to int

### Resources used
- https://chatgpt.com/c/673d87f0-1060-800c-a838-19b494b13f04
- https://stackoverflow.com/questions/7999295/rest-api-authentication
- https://stackoverflow.com/questions/2382532/how-can-i-get-the-sql-of-a-preparedstatement

